### PR TITLE
Request: Consider HTTP 204 as BucketAlreadyExists error

### DIFF
--- a/swift3/request.py
+++ b/swift3/request.py
@@ -1199,6 +1199,7 @@ class Request(swob.Request):
                     HTTP_NOT_FOUND: (NoSuchBucket, container),
                 },
                 'PUT': {
+                    HTTP_NO_CONTENT: (BucketAlreadyExists, container),
                     HTTP_ACCEPTED: (BucketAlreadyExists, container),
                 },
                 'POST': {


### PR DESCRIPTION
Swift return a 202 Accepted when a bucket already exists.
But openio-sds return 204 No Content.
So now we should accept both status codes as valid answer.