### PR TITLE
Expose name of S3 operations

### DIFF
--- a/swift3/controllers/acl.py
+++ b/swift3/controllers/acl.py
@@ -88,6 +88,7 @@ class AclController(Controller):
         """
         Handles GET Bucket acl and GET Object acl.
         """
+        req.environ.setdefault('swift.log_info', []).append("get-acl")
         resp = req.get_response(self.app, method='HEAD')
 
         return get_acl(req.user_id, resp.headers)
@@ -97,6 +98,7 @@ class AclController(Controller):
         """
         Handles PUT Bucket acl and PUT Object acl.
         """
+        req.environ.setdefault('swift.log_info', []).append("put-acl")
         if req.is_object_request:
             # Handle Object ACL
             raise S3NotImplemented()

--- a/swift3/controllers/cors.py
+++ b/swift3/controllers/cors.py
@@ -156,6 +156,7 @@ class CorsController(Controller):
         """
         Handles GET Bucket CORS.
         """
+        req.environ.setdefault('swift.log_info', []).append('get-bucket-cors')
         resp = req._get_response(self.app, 'HEAD',
                                  req.container_name, None)
         body = resp.sysmeta_headers.get(BUCKET_CORS_HEADER)
@@ -169,6 +170,7 @@ class CorsController(Controller):
         """
         Handles PUT Bucket CORs.
         """
+        req.environ.setdefault('swift.log_info', []).append('put-bucket-cors')
         xml = req.xml(MAX_CORS_BODY_SIZE)
         try:
             data = fromstring(xml, "CorsConfiguration")
@@ -192,6 +194,8 @@ class CorsController(Controller):
         """
         Handles DELETE Bucket CORs.
         """
+        req.environ.setdefault('swift.log_info', []).append(
+            'delete-bucket-cors')
         req.headers[BUCKET_CORS_HEADER] = ''
         resp = req._get_response(self.app, 'POST',
                                  req.container_name, None)

--- a/swift3/controllers/multi_delete.py
+++ b/swift3/controllers/multi_delete.py
@@ -52,6 +52,8 @@ class MultiObjectDeleteController(Controller):
         """
         Handles Delete Multiple Objects.
         """
+        req.environ.setdefault('swift.log_info', []).append('delete-objects')
+
         def object_key_iter(elem):
             for obj in elem.iterchildren('Object'):
                 key = obj.find('./Key').text

--- a/swift3/controllers/service.py
+++ b/swift3/controllers/service.py
@@ -31,6 +31,7 @@ class ServiceController(Controller):
         """
         Handle GET Service request
         """
+        req.environ.setdefault('swift.log_info', []).append('list-buckets')
         resp = req.get_response(self.app, query={'format': 'json'})
 
         containers = json.loads(resp.body)

--- a/swift3/controllers/unique_bucket.py
+++ b/swift3/controllers/unique_bucket.py
@@ -29,6 +29,7 @@ class UniqueBucketController(BucketController):
         """
         Handle PUT Bucket request
         """
+        req.environ.setdefault('swift.log_info', []).append('create-bucket')
         # We are about to create a container, reserve its name.
         can_create = req.bucket_db.reserve(req.container_name, req.account)
         if not can_create:
@@ -52,6 +53,7 @@ class UniqueBucketController(BucketController):
         """
         Handle DELETE Bucket request
         """
+        req.environ.setdefault('swift.log_info', []).append('delete-bucket')
         try:
             resp = super(UniqueBucketController, self).DELETE(req)
         except NoSuchBucket:

--- a/swift3/controllers/versioning.py
+++ b/swift3/controllers/versioning.py
@@ -39,6 +39,8 @@ class VersioningController(Controller):
         """
         Handles GET Bucket versioning.
         """
+        req.environ.setdefault('swift.log_info', []).append(
+            'get-bucket-versioning')
         info = req.get_container_info(self.app)
         status = None
         versions_container = info.get('sysmeta', {}).get('versions-location')
@@ -69,6 +71,8 @@ class VersioningController(Controller):
         """
         Handles PUT Bucket versioning.
         """
+        req.environ.setdefault('swift.log_info', []).append(
+            'put-bucket-versioning')
         xml = req.xml(MAX_PUT_VERSIONING_BODY_SIZE)
         try:
             elem = fromstring(xml, 'VersioningConfiguration')


### PR DESCRIPTION
Each method will now expose the "s3api" method through the `swift.log_info` used by `proxy-logging` middleware: it is located just before 'start_time' field
```swift: 127.0.0.1 127.0.0.1 20/Dec/2019/08/40/43 GET /titi/magic HTTP/1.0 200 - aws-cli/1.16.298%20Python/2.7.16%20Linux/5.0.0-37-generic%20botocore/1.13.41 - - 111 - tx04cf650413234a8ca3f27-005dfc890b - 0.0241 - get-object 1576831243.650888920 1576831243.674968004 -

```