### PR TITLE
Add flag to export s3api method

### DIFF
--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -131,6 +131,9 @@ use = egg:swift3#swift3
 # upload, except the last part.
 min_segment_size = 5242880
 
+# Expose S3API method in swift log
+#log_s3api_command = False
+
 # log_name = swift3
 
 # Enable the Redis-based bucket database. This will make the bucket names

--- a/swift3/cfg.py
+++ b/swift3/cfg.py
@@ -72,5 +72,6 @@ CONF = Config({
     'force_swift_request_proxy_log': False,
     'allow_multipart_uploads': True,
     'min_segment_size': 5242880,
-    'allow_anymous_path_request': True
+    'allow_anymous_path_request': True,
+    'log_s3api_command': False
 })

--- a/swift3/controllers/acl.py
+++ b/swift3/controllers/acl.py
@@ -23,6 +23,7 @@ from swift3.response import HTTPOk, S3NotImplemented, MalformedACLError, \
     UnexpectedContent, MissingSecurityHeader
 from swift3.etree import Element, SubElement, tostring
 from swift3.acl_utils import swift_acl_translate, XMLNS_XSI
+from swift3.utils import log_s3api_command
 
 
 MAX_ACL_BODY_SIZE = 200 * 1024
@@ -88,7 +89,7 @@ class AclController(Controller):
         """
         Handles GET Bucket acl and GET Object acl.
         """
-        req.environ.setdefault('swift.log_info', []).append("get-acl")
+        log_s3api_command(req, 'get-acl')
         resp = req.get_response(self.app, method='HEAD')
 
         return get_acl(req.user_id, resp.headers)
@@ -98,7 +99,7 @@ class AclController(Controller):
         """
         Handles PUT Bucket acl and PUT Object acl.
         """
-        req.environ.setdefault('swift.log_info', []).append("put-acl")
+        log_s3api_command(req, 'put-acl')
         if req.is_object_request:
             # Handle Object ACL
             raise S3NotImplemented()

--- a/swift3/controllers/cors.py
+++ b/swift3/controllers/cors.py
@@ -22,7 +22,7 @@ from swift3.etree import fromstring, DocumentInvalid, XMLSyntaxError
 from swift3.response import HTTPOk, HTTPNoContent, MalformedXML, \
     NoSuchCORSConfiguration, CORSInvalidRequest
 
-from swift3.utils import LOGGER, sysmeta_header
+from swift3.utils import LOGGER, sysmeta_header, log_s3api_command
 
 VERSION_ID_HEADER = 'X-Object-Sysmeta-Version-Id'
 
@@ -156,7 +156,7 @@ class CorsController(Controller):
         """
         Handles GET Bucket CORS.
         """
-        req.environ.setdefault('swift.log_info', []).append('get-bucket-cors')
+        log_s3api_command(req, 'get-bucket-cors')
         resp = req._get_response(self.app, 'HEAD',
                                  req.container_name, None)
         body = resp.sysmeta_headers.get(BUCKET_CORS_HEADER)
@@ -170,7 +170,7 @@ class CorsController(Controller):
         """
         Handles PUT Bucket CORs.
         """
-        req.environ.setdefault('swift.log_info', []).append('put-bucket-cors')
+        log_s3api_command(req, 'put-bucket-cors')
         xml = req.xml(MAX_CORS_BODY_SIZE)
         try:
             data = fromstring(xml, "CorsConfiguration")
@@ -194,8 +194,7 @@ class CorsController(Controller):
         """
         Handles DELETE Bucket CORs.
         """
-        req.environ.setdefault('swift.log_info', []).append(
-            'delete-bucket-cors')
+        log_s3api_command(req, 'delete-bucket-cors')
         req.headers[BUCKET_CORS_HEADER] = ''
         resp = req._get_response(self.app, 'POST',
                                  req.container_name, None)

--- a/swift3/controllers/multi_delete.py
+++ b/swift3/controllers/multi_delete.py
@@ -22,7 +22,7 @@ from swift3.response import HTTPOk, S3NotImplemented, \
     ErrorResponse, MalformedXML, UserKeyMustBeSpecified, AccessDenied, \
     MissingRequestBodyError
 from swift3.cfg import CONF
-from swift3.utils import LOGGER
+from swift3.utils import LOGGER, log_s3api_command
 
 # 1000 keys with len 1024 and XML overhead
 MAX_MULTI_DELETE_BODY_SIZE = 1536000
@@ -52,7 +52,7 @@ class MultiObjectDeleteController(Controller):
         """
         Handles Delete Multiple Objects.
         """
-        req.environ.setdefault('swift.log_info', []).append('delete-objects')
+        log_s3api_command(req, 'delete-objects')
 
         def object_key_iter(elem):
             for obj in elem.iterchildren('Object'):

--- a/swift3/controllers/multi_upload.py
+++ b/swift3/controllers/multi_upload.py
@@ -61,7 +61,7 @@ from swift3.response import InvalidArgument, ErrorResponse, MalformedXML, \
     InvalidRequest, HTTPOk, HTTPNoContent, NoSuchKey, NoSuchUpload, \
     NoSuchBucket, InvalidRange, BadDigest
 from swift3.utils import LOGGER, unique_id, MULTIUPLOAD_SUFFIX, S3Timestamp, \
-    extract_s3_etag
+    extract_s3_etag, log_s3api_command
 from swift3.etree import Element, SubElement, fromstring, tostring, \
     XMLSyntaxError, DocumentInvalid
 from swift3.cfg import CONF
@@ -166,7 +166,7 @@ class PartController(Controller):
             req.headers['Range'] = rng
             del req.headers['X-Amz-Copy-Source-Range']
 
-        req.environ.setdefault('swift.log_info', []).append(method)
+        log_s3api_command(req, method)
         resp = req.get_response(self.app)
 
         if 'X-Amz-Copy-Source' in req.headers:
@@ -183,7 +183,7 @@ class PartController(Controller):
         """
         Handles Get Part (regular Get but with ?part-number=N).
         """
-        req.environ.setdefault('swift.log_info', []).append('get-object-part')
+        log_s3api_command(req, 'get-object-part')
         return self.GETorHEAD(req)
 
     @public
@@ -193,7 +193,7 @@ class PartController(Controller):
         """
         Handles Head Part (regular HEAD but with ?part-number=N).
         """
-        req.environ.setdefault('swift.log_info', []).append('head-object-part')
+        log_s3api_command(req, 'head-object-part')
         return self.GETorHEAD(req)
 
     def GETorHEAD(self, req):
@@ -260,8 +260,7 @@ class UploadsController(Controller):
         Handles List Multipart Uploads
         """
 
-        req.environ.setdefault('swift.log_info', []).append(
-            'list-multipart-uploads')
+        log_s3api_command(req, 'list-multipart-uploads')
 
         def separate_uploads(uploads, prefix, delimiter):
             """
@@ -412,8 +411,7 @@ class UploadsController(Controller):
         Handles Initiate Multipart Upload.
         """
 
-        req.environ.setdefault('swift.log_info', []).append(
-            'create-multipart-upload')
+        log_s3api_command(req, 'create-multipart-upload')
         # Create a unique S3 upload id from UUID to avoid duplicates.
         upload_id = unique_id()
 
@@ -457,7 +455,7 @@ class UploadController(Controller):
         """
         Handles List Parts.
         """
-        req.environ.setdefault('swift.log_info', []).append('list-parts')
+        log_s3api_command(req, 'list-parts')
 
         def filter_part_num_marker(o):
             try:
@@ -556,8 +554,7 @@ class UploadController(Controller):
         """
         Handles Abort Multipart Upload.
         """
-        req.environ.setdefault('swift.log_info', []).append(
-            'abort-multipart-upload')
+        log_s3api_command(req, 'abort-multipart-upload')
         upload_id = req.params['uploadId']
         _check_upload_info(req, self.app, upload_id)
 
@@ -596,8 +593,7 @@ class UploadController(Controller):
         """
         Handles Complete Multipart Upload.
         """
-        req.environ.setdefault('swift.log_info', []).append(
-            'complete-multipart-upload')
+        log_s3api_command(req, 'complete-multipart-upload')
         upload_id = req.params['uploadId']
         resp = _get_upload_info(req, self.app, upload_id)
         headers = {}

--- a/swift3/controllers/obj.py
+++ b/swift3/controllers/obj.py
@@ -19,7 +19,8 @@ from swift.common.middleware.versioned_writes import \
 from swift.common.swob import Range, content_range_header_value
 from swift.common.utils import public
 
-from swift3.utils import S3Timestamp, VERSIONING_SUFFIX, versioned_object_name
+from swift3.utils import S3Timestamp, VERSIONING_SUFFIX, \
+    versioned_object_name, log_s3api_command
 from swift3.controllers.base import Controller
 from swift3.controllers.cors import get_cors, cors_fill_headers, \
     CORS_ALLOWED_HTTP_METHOD
@@ -115,7 +116,7 @@ class ObjectController(Controller):
         """
         Handle HEAD Object request
         """
-        req.environ.setdefault('swift.log_info', []).append('head-object')
+        log_s3api_command(req, 'head-object')
         resp = self.GETorHEAD(req)
 
         if 'range' in req.headers:
@@ -129,7 +130,7 @@ class ObjectController(Controller):
         """
         Handle GET Object request
         """
-        req.environ.setdefault('swift.log_info', []).append("get-object")
+        log_s3api_command(req, 'get-object')
         return self.GETorHEAD(req)
 
     @public
@@ -158,7 +159,7 @@ class ObjectController(Controller):
             for key in list(resp.headers.keys()):
                 if key.startswith('x-amz-meta-'):
                     del resp.headers[key]
-        req.environ.setdefault('swift.log_info', []).append(method)
+        log_s3api_command(req, method)
         resp.status = HTTP_OK
         return resp
 
@@ -195,7 +196,7 @@ class ObjectController(Controller):
         """
         Handle DELETE Object request
         """
-        req.environ.setdefault('swift.log_info', []).append('delete-object')
+        log_s3api_command(req, 'delete-object')
         try:
             query = req.gen_multipart_manifest_delete_query(self.app)
             req.headers['Content-Type'] = None  # Ignore client content-type

--- a/swift3/controllers/service.py
+++ b/swift3/controllers/service.py
@@ -18,7 +18,7 @@ from swift.common.utils import json, public, last_modified_date_to_timestamp
 from swift3.controllers.base import Controller
 from swift3.etree import Element, SubElement, tostring
 from swift3.response import HTTPOk, AccessDenied, NoSuchBucket
-from swift3.utils import validate_bucket_name, S3Timestamp
+from swift3.utils import validate_bucket_name, S3Timestamp, log_s3api_command
 from swift3.cfg import CONF
 
 
@@ -31,7 +31,7 @@ class ServiceController(Controller):
         """
         Handle GET Service request
         """
-        req.environ.setdefault('swift.log_info', []).append('list-buckets')
+        log_s3api_command(req, 'list-buckets')
         resp = req.get_response(self.app, query={'format': 'json'})
 
         containers = json.loads(resp.body)

--- a/swift3/controllers/unique_bucket.py
+++ b/swift3/controllers/unique_bucket.py
@@ -17,6 +17,7 @@ from swift.common.utils import public
 from swift3.controllers import BucketController
 from swift3.response import BucketAlreadyExists, BucketAlreadyOwnedByYou, \
     NoSuchBucket
+from swift3.utils import log_s3api_command
 
 
 class UniqueBucketController(BucketController):
@@ -29,7 +30,7 @@ class UniqueBucketController(BucketController):
         """
         Handle PUT Bucket request
         """
-        req.environ.setdefault('swift.log_info', []).append('create-bucket')
+        log_s3api_command(req, 'create-bucket')
         # We are about to create a container, reserve its name.
         can_create = req.bucket_db.reserve(req.container_name, req.account)
         if not can_create:
@@ -53,7 +54,7 @@ class UniqueBucketController(BucketController):
         """
         Handle DELETE Bucket request
         """
-        req.environ.setdefault('swift.log_info', []).append('delete-bucket')
+        log_s3api_command(req, 'delete-bucket')
         try:
             resp = super(UniqueBucketController, self).DELETE(req)
         except NoSuchBucket:

--- a/swift3/controllers/versioning.py
+++ b/swift3/controllers/versioning.py
@@ -19,7 +19,7 @@ from swift3.controllers.base import Controller, bucket_operation
 from swift3.etree import Element, tostring, fromstring, XMLSyntaxError, \
     DocumentInvalid, SubElement
 from swift3.response import HTTPOk, NoSuchBucket, MalformedXML
-from swift3.utils import LOGGER, VERSIONING_SUFFIX
+from swift3.utils import LOGGER, VERSIONING_SUFFIX, log_s3api_command
 
 MAX_PUT_VERSIONING_BODY_SIZE = 10240
 
@@ -39,8 +39,7 @@ class VersioningController(Controller):
         """
         Handles GET Bucket versioning.
         """
-        req.environ.setdefault('swift.log_info', []).append(
-            'get-bucket-versioning')
+        log_s3api_command(req, 'get-bucket-versioning')
         info = req.get_container_info(self.app)
         status = None
         versions_container = info.get('sysmeta', {}).get('versions-location')
@@ -71,8 +70,7 @@ class VersioningController(Controller):
         """
         Handles PUT Bucket versioning.
         """
-        req.environ.setdefault('swift.log_info', []).append(
-            'put-bucket-versioning')
+        log_s3api_command(req, 'put-bucket-versioning')
         xml = req.xml(MAX_PUT_VERSIONING_BODY_SIZE)
         try:
             elem = fromstring(xml, 'VersioningConfiguration')

--- a/swift3/utils.py
+++ b/swift3/utils.py
@@ -228,3 +228,14 @@ def extract_s3_etag(content_type):
         else:
             content_type += ';%s=%s' % (key, value)
     return content_type, s3_etag
+
+
+def log_s3api_command(req, command):
+    """
+    Append s3api command to current request in swift.log_info fields.
+
+    :param req: HTTP request object
+    :param command: s3 command string
+    """
+    if CONF.log_s3api_command:
+        req.environ.setdefault('swift.log_info', []).append(command)


### PR DESCRIPTION
As 0154c20fdacc9d46750efb81eb476959578d127d may break monitoring, the
s3api method will be exposed only if configuration variable
`log_s3api` is set.