### PR TITLE
Add optimisation around uploadId

### DIFF
--- a/swift3/acl_handlers.py
+++ b/swift3/acl_handlers.py
@@ -178,6 +178,9 @@ class BucketAclHandler(BaseAclHandler):
             return self._handle_acl(app, 'GET')
 
     def PUT(self, app):
+        if self.container.endswith(MULTIUPLOAD_SUFFIX):
+            # create multiupload container doesn't need acls
+            return
         req_acl = ACL.from_headers(self.req.headers,
                                    Owner(self.user_id, self.user_id))
 

--- a/swift3/bucket_db.py
+++ b/swift3/bucket_db.py
@@ -15,6 +15,7 @@
 
 import time
 import importlib
+from six import string_types
 from swift.common.utils import config_true_value
 
 try:
@@ -55,7 +56,7 @@ except ImportError:
             if not sentinel_name:
                 raise ValueError("missing parameter 'sentinel_name'")
 
-            if isinstance(sentinel_hosts, basestring):
+            if isinstance(sentinel_hosts, string_types):
                 sentinel_hosts = sentinel_hosts.split(',')
             self._sentinel_hosts = [(h, int(p)) for h, p, in (hp.rsplit(':', 1)
                                     for hp in sentinel_hosts)]
@@ -166,7 +167,6 @@ class DummyBucketDb(object):
 class RedisBucketDb(RedisConnection):
     """
     Keep a list of buckets with their associated account.
-    Dummy in-memory implementation.
     """
 
     def __init__(self, host=None, sentinel_hosts=None, sentinel_name=None,

--- a/swift3/cfg.py
+++ b/swift3/cfg.py
@@ -73,5 +73,5 @@ CONF = Config({
     'allow_multipart_uploads': True,
     'min_segment_size': 5242880,
     'allow_anymous_path_request': True,
-    'log_s3api_command': False
+    'log_s3api_command': False,
 })

--- a/swift3/controllers/obj.py
+++ b/swift3/controllers/obj.py
@@ -109,7 +109,7 @@ class ObjectController(Controller):
             if 'response-' + key in req.params:
                 resp.headers[key] = req.params['response-' + key]
 
-        if cors_rule:
+        if cors_rule is not None:
             cors_fill_headers(req, resp, cors_rule)
         return resp
 

--- a/swift3/test/unit/test_bucket.py
+++ b/swift3/test/unit/test_bucket.py
@@ -48,6 +48,8 @@ class TestSwift3Bucket(Swift3TestCase):
         for p in self.prefixes:
             object_list_subdir.append({"subdir": p})
 
+        self.swift.register('PUT', '/v1/AUTH_test/bucket+segments',
+                            swob.HTTPNoContent, {}, json.dumps([]))
         self.swift.register('DELETE', '/v1/AUTH_test/bucket+segments',
                             swob.HTTPNoContent, {}, json.dumps([]))
         self.swift.register('DELETE', '/v1/AUTH_test/bucket+segments/rose',

--- a/swift3/test/unit/test_bucket_db.py
+++ b/swift3/test/unit/test_bucket_db.py
@@ -33,11 +33,16 @@ class TestSwift3BucketDb(Swift3TestCase):
         super(TestSwift3BucketDb, self).setUp()
         self.swift.register('PUT', '/v1/AUTH_test2/bucket',
                             swob.HTTPCreated, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_test2/bucket+segments',
+                            swob.HTTPNoContent, {}, None)
         self.swift.register('PUT', '/v1/AUTH_test/bucket-server-error',
                             swob.HTTPServerError, {}, None)
         self.swift.register(
             'HEAD', '/v1/AUTH_test/bucket', swob.HTTPNoContent,
             {'X-Container-Object-Count': 0}, None)
+        self.swift.register(
+            'PUT', '/v1/AUTH_test/bucket+segments', swob.HTTPNoContent,
+            {}, None)
         self.swift.register(
             'GET', '/v1/AUTH_test/bucket+segments?format=json&marker=',
             swob.HTTPNotFound, {}, None)
@@ -103,7 +108,8 @@ class TestSwift3BucketDb(Swift3TestCase):
 
     def test_bucket_DELETE(self):
         self.assertIsNone(self.db.get_owner('bucket'))
-        status, _, _ = self._bucket_put()
+        status, body, _ = self._bucket_put()
+        print(body)
         self.assertEqual(status.split()[0], '200')
         self.assertEqual(self.db.get_owner('bucket'), 'AUTH_test')
 

--- a/swift3/test/unit/test_middleware.py
+++ b/swift3/test/unit/test_middleware.py
@@ -924,6 +924,8 @@ class TestSwift3Middleware(Swift3TestCase):
                      'Date': self.get_date_header()})
         self.swift.register('PUT', '/v1/AUTH_TENANT_ID/bucket',
                             swob.HTTPCreated, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_TENANT_ID/bucket+segments',
+                            swob.HTTPCreated, {}, None)
         self.swift.register('HEAD', '/v1/AUTH_TENANT_ID',
                             swob.HTTPOk, {}, None)
         with patch.object(self.s3_token, '_json_request') as mock_req:
@@ -934,7 +936,7 @@ class TestSwift3Middleware(Swift3TestCase):
 
             status, headers, body = self.call_swift3(req)
             self.assertEqual(body, '')
-            self.assertEqual(1, mock_req.call_count)
+            self.assertEqual(2, mock_req.call_count)
 
     def test_swift3_with_only_s3_token_v3(self):
         self.swift = FakeSwift()
@@ -950,6 +952,8 @@ class TestSwift3Middleware(Swift3TestCase):
                      'Date': self.get_date_header()})
         self.swift.register('PUT', '/v1/AUTH_PROJECT_ID/bucket',
                             swob.HTTPCreated, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_PROJECT_ID/bucket+segments',
+                            swob.HTTPCreated, {}, None)
         self.swift.register('HEAD', '/v1/AUTH_PROJECT_ID',
                             swob.HTTPOk, {}, None)
         with patch.object(self.s3_token, '_json_request') as mock_req:
@@ -960,7 +964,7 @@ class TestSwift3Middleware(Swift3TestCase):
 
             status, headers, body = self.call_swift3(req)
             self.assertEqual(body, '')
-            self.assertEqual(1, mock_req.call_count)
+            self.assertEqual(2, mock_req.call_count)
 
     def test_swift3_with_s3_token_and_auth_token(self):
         self.swift = FakeSwift()
@@ -977,6 +981,8 @@ class TestSwift3Middleware(Swift3TestCase):
             headers={'Authorization': 'AWS access:signature',
                      'Date': self.get_date_header()})
         self.swift.register('PUT', '/v1/AUTH_TENANT_ID/bucket',
+                            swob.HTTPCreated, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_TENANT_ID/bucket+segments',
                             swob.HTTPCreated, {}, None)
         self.swift.register('HEAD', '/v1/AUTH_TENANT_ID',
                             swob.HTTPOk, {}, None)
@@ -995,10 +1001,10 @@ class TestSwift3Middleware(Swift3TestCase):
 
                 status, headers, body = self.call_swift3(req)
                 self.assertEqual(body, '')
-                self.assertEqual(1, mock_req.call_count)
+                self.assertEqual(2, mock_req.call_count)
                 # With X-Auth-Token, auth_token will call _do_fetch_token to
                 # connect to keystone in auth_token, again
-                self.assertEqual(1, mock_fetch.call_count)
+                self.assertEqual(2, mock_fetch.call_count)
 
     def test_swift3_with_s3_token_no_pass_token_to_auth_token(self):
         self.swift = FakeSwift()
@@ -1015,6 +1021,8 @@ class TestSwift3Middleware(Swift3TestCase):
             headers={'Authorization': 'AWS access:signature',
                      'Date': self.get_date_header()})
         self.swift.register('PUT', '/v1/AUTH_TENANT_ID/bucket',
+                            swob.HTTPCreated, {}, None)
+        self.swift.register('PUT', '/v1/AUTH_TENANT_ID/bucket+segments',
                             swob.HTTPCreated, {}, None)
         self.swift.register('HEAD', '/v1/AUTH_TENANT_ID',
                             swob.HTTPOk, {}, None)


### PR DESCRIPTION

- Skip creating bucket+segment as our backend is always in autocreate mode
- Enrich uploadId request with oio.cache-object
- Enrich list-multipart-upload with oio.list-mpu

A change has been cherry-pick from s3api but commit was lost between swift3 and s3api integration.