### PR TITLE
Skip empty x-amz-acl headers

### DIFF
--- a/swift3/subresource.py
+++ b/swift3/subresource.py
@@ -505,10 +505,12 @@ class ACL(object):
                         err_msg = 'Specifying both Canned ACLs and Header ' \
                             'Grants is not allowed'
                         raise InvalidRequest(err_msg)
-                    grantees = canned_acl_grantees(
-                        bucket_owner, object_owner)[acl]
-                    for permission, grantee in grantees:
-                        grants.append(Grant(grantee, permission))
+                    # skip empty ACL headers sent by clients
+                    if len(acl):
+                        grantees = canned_acl_grantees(
+                            bucket_owner, object_owner)[acl]
+                        for permission, grantee in grantees:
+                            grants.append(Grant(grantee, permission))
                 except KeyError:
                     # expects canned_acl_grantees()[] raises KeyError
                     raise InvalidArgument('x-amz-acl', headers['x-amz-acl'])

--- a/swift3/test/unit/test_s3_acl.py
+++ b/swift3/test/unit/test_s3_acl.py
@@ -537,5 +537,15 @@ class TestSwift3S3Acl(Swift3TestCase):
         self.assertRaises(TypeError, fake_class.s3acl_s3only_error)
         self.assertIsNone(fake_class.s3acl_s3only_no_error())
 
+    def test_object_empty_acl(self):
+        req = Request.blank('/bucket/object',
+                            environ={'REQUEST_METHOD': 'PUT'},
+                            headers={'Authorization': 'AWS test:tester:hmac',
+                                     'Date': self.get_date_header(),
+                                     'x-amz-acl': ''})
+        status, headers, body = self.call_swift3(req)
+        self.assertEqual(status.split()[0], '200')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When x-amz-acl header is sent without value, the gateway returns a 400 error.

With AWS S3, the empty value is ignored and use default value:

```
$ aws s3api put-object --bucket test-empy-acl --key /etc/magic --acl ''
$ aws s3api get-object-acl --bucket test-empy-acl --key /etc/magic
{
    "Owner": {
        "ID": "69a360b85b319b998292fbac13803cdc79898d1d2ed0f29f3a245874xxxxxx"
    },
    "Grants": [
        {
            "Grantee": {
                "ID": "69a360b85b319b998292fbac13803cdc79898d1d2ed0f29f3a245874xxxxxx",
                "Type": "CanonicalUser"
            },
            "Permission": "FULL_CONTROL"
        }
    ]
}
```